### PR TITLE
Added options to filerev-apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ Default value: `''`
 
 The string to strip from the beginning of each found revved file before search for it in the specified files. `options.prefix` will likely be used in the majority of cases.
 
+You can use an string Array to strip multiples paths sequentially in searches.
+
+### Usage Examples
+
+-build
+|- app
+|- assets
+
+```javascript
+prefix: ['build', 'assets']
+```
+Will ignore "build" AND "build/assets", but NOT "build/app"
+
+#### options.unixfy
+Type: `Boolean`
+Default value: `false`
+
+The unixfy when set true changes the default Windows path separator from '\' to '/' before search.
+
 ### Usage Examples
 
 #### Default Options

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ You can use an string Array to strip multiples paths sequentially in searches.
 
 ### Usage Examples
 
--build
-|- app
-|- assets
+-build  
+|- app  
+|- assets  
 
 ```javascript
 prefix: ['build', 'assets']


### PR DESCRIPTION
- Added option to "unixfy" paths in search to replace, changing backslash to front slash in paths. (helpful when using *nix like js path references in Windows)
- Added option to ignore multiples paths in "prefix". Example below.
- Fix when use prefix with multiple root paths. (changed substr to replace(regex(startsWith)))

Multiple prefix example:

-build
|- app
|- assets

"prefix: ['build', 'assets']": will ignore "build" AND "build/assets", but NOT "build/app"
