### PR TITLE
replace slash to work in windows env

### DIFF
--- a/tasks/filerev_apply.js
+++ b/tasks/filerev_apply.js
@@ -20,7 +20,9 @@ module.exports = function (grunt) {
 
     var summary = {};
     _.each(grunt.filerev.summary, function(value, key) {
-      summary[key.substr(options.prefix.length)] = value.substr(options.prefix.length);
+      key = key.substr(options.prefix.length).replace(/\\/g, "/");
+      value = value.substr(options.prefix.length).replace(/\\/g, "/");
+      summary[key] = value;
     });
 
     var pattern = new RegExp('(' + _.keys(summary).join(')|(') + ')', 'g');


### PR DESCRIPTION
Hello @ianwremmel !

I'm sending this PR to fix an issue only for windows env. It´s a simple replace on a slash returned by grunt file rev summary that´s not affects unix mode. Could you please check and merge it?

Thank you for building this task!