### PR TITLE
Multiple index.html deep (so prefix)

### DIFF
--- a/tasks/filerev_apply.js
+++ b/tasks/filerev_apply.js
@@ -20,8 +20,8 @@ module.exports = function (grunt) {
 
     var summary = {};
     _.each(grunt.filerev.summary, function(value, key) {
-      key = key.substr(options.prefix.length).replace(/\\/g, "/");
-      value = value.substr(options.prefix.length).replace(/\\/g, "/");
+      key = key.replace(/\\/g, "/").replace(options.prefix, "");
+      value = value.replace(/\\/g, "/").replace(options.prefix, "");
       summary[key] = value;
     });
 


### PR DESCRIPTION
Fix issue when task exectuted on multiple index.html with multiple deep and so multiple "prefix", which **cut files path instead of remove prefix** (event if file does not contain this prefix).